### PR TITLE
Add account management tabs and backend hooks

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,55 @@
+export async function analyzeImages(files) {
+  const formData = new FormData();
+  files.forEach(file => formData.append('images', file));
+  try {
+    const response = await fetch('/api/analyze', {
+      method: 'POST',
+      body: formData
+    });
+    if (!response.ok) throw new Error('Image analysis failed');
+    return await response.json();
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+}
+
+export async function createBooking(data) {
+  try {
+    const response = await fetch('/api/bookings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    if (!response.ok) throw new Error('Booking failed');
+    return await response.json();
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+}
+
+export async function fetchPaymentMethods() {
+  // Placeholder for fetching payment methods from backend
+  return [];
+}
+
+export async function savePaymentMethod(method) {
+  // Placeholder for saving a payment method
+  return method;
+}
+
+export async function fetchAddresses() {
+  // Placeholder for fetching saved addresses from backend
+  return [];
+}
+
+export async function saveAddress(address) {
+  // Placeholder for saving a new address
+  return address;
+}
+
+export async function saveCustomizationSettings(settings) {
+  // Placeholder for saving user customization settings
+  return settings;
+}


### PR DESCRIPTION
## Summary
- add API module with placeholders for image analysis, booking creation, and account data persistence
- integrate image analysis and booking creation hooks in the main app
- redesign Account screen with tabs for payment methods, saved addresses, and customization settings

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688ff2eb2280832099a1765f4ea38381