### PR TITLE
Add Link Pay integration

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { Pool } = require('pg');
+const crypto = require('crypto');
 
 const app = express();
 app.use(express.json());
@@ -159,6 +160,15 @@ app.post('/api/users/payments', async (req, res) => {
   } catch (err) {
     handleError(res, err);
   }
+});
+
+app.post('/api/payments/link', (req, res) => {
+  const { amount } = req.body;
+  if (typeof amount !== 'number') {
+    return res.status(400).json({ error: 'amount required' });
+  }
+  const token = crypto.randomBytes(8).toString('hex');
+  res.json({ url: `https://pay.local/checkout/${token}?amount=${amount}` });
 });
 
 app.use((req, res) => {

--- a/src/TrashPickupApp.js
+++ b/src/TrashPickupApp.js
@@ -24,6 +24,7 @@ import {
   fetchPaymentMethods,
   fetchAddresses,
   savePaymentMethod,
+  createLinkPay,
   saveAddress,
   saveCustomizationSettings,
   login,
@@ -263,6 +264,7 @@ const TrashPickupApp = () => {
   const [errors, setErrors] = useState({});
   const [bookingLoading, setBookingLoading] = useState(false);
   const [completedSteps, setCompletedSteps] = useState({});
+  const [linkPayUrl, setLinkPayUrl] = useState('');
 
   useEffect(() => {
     async function loadAccountData() {
@@ -1131,6 +1133,32 @@ const TrashPickupApp = () => {
               >
                 Add
               </button>
+            </div>
+            <div className="pt-4">
+              <button
+                type="button"
+                onClick={async () => {
+                  try {
+                    const url = await createLinkPay(50);
+                    setLinkPayUrl(url);
+                  } catch (err) {
+                    console.error(err);
+                  }
+                }}
+                className="bg-blue-600 text-white px-4 py-2 rounded-xl font-bold hover:bg-blue-700 transition-colors"
+              >
+                Generate Link Pay
+              </button>
+              {linkPayUrl && (
+                <a
+                  href={linkPayUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="ml-2 text-blue-600 underline"
+                >
+                  Pay with Link
+                </a>
+              )}
             </div>
           </div>
         )}

--- a/src/api.js
+++ b/src/api.js
@@ -33,6 +33,19 @@ export async function savePaymentMethod(method) {
   return method;
 }
 
+export async function createLinkPay(amount) {
+  const res = await fetch('/api/payments/link', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ amount })
+  });
+  if (!res.ok) {
+    throw new Error('Failed to create Link Pay link');
+  }
+  const data = await res.json();
+  return data.url;
+}
+
 export async function fetchAddresses() {
   // Placeholder for fetching saved addresses from backend
   return [];


### PR DESCRIPTION
## Summary
- add backend endpoint to generate Link Pay links
- expose API helper and UI button to create Link Pay link

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68902d383a008320b6c6ec670db09600